### PR TITLE
Why use params?

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -5,13 +5,9 @@ class TodosController < ApplicationController
   expose(:todos) { current_user.todos }
 
   def create
-    current_user.todos.create(todo_params)
-    redirect_to todos_path
+    todo_params = params[:todo]
+    current_user.todos.create(title: todo_params[:title])
+    redirect_to '/'
   end
 
-  private
-
-  def todo_params
-    params.require(:todo).permit(:title)
-  end
 end


### PR DESCRIPTION
I know we're not supposed to do it this way.  Threading the params into the `create` method is how it's always been done.

But think back to the Github hack where that programmer learned how to give himself admin rights to the rails repository.  So they quickly add `attr_accessible` to the models.  Oh, but that's wrong, now we're switching the behavior to the controller... with its own new syntax.

But people using Sinatra or using Rails in a different way just sit back and laugh... we haven't had to change our code.  We just pass the values we need on the properties we set.

This PR just shows that it can work the same... with less code... and less getting jerked around when Rails gets updated again.
